### PR TITLE
fix: add `--bind` param to `htp`

### DIFF
--- a/etc.go
+++ b/etc.go
@@ -36,6 +36,7 @@ var (
 	Database   dbstorage.Database
 	ConfigPath string
 	JWTSecret  string
+	Bind       string
 	Port       int
 	Epoch      = internal.Epoch
 	HtpErrCb   = func(r *http.Request, w http.ResponseWriter, good bool, status int, message string) {}
@@ -51,7 +52,8 @@ var (
 func PreInit() {
 	vflag.StringArrayVar(&appFlagTheme, "theme", []string{}, "A CLI way to add config themes.")
 	vflag.StringVar(&ConfigPath, "config", homedirV+"/.config/"+AppID+"/config.json", "")
-	vflag.StringVar(&JWTSecret, "jwt-secret", util.RandomString(64), "Privte secret to sign and verify JWT auth tokens with.")
+	vflag.StringVar(&JWTSecret, "jwt-secret", util.RandomString(64), "Private secret to sign and verify JWT auth tokens with.")
+	vflag.StringVar(&Bind, "bind", "127.0.0.1", "IP to bind")
 	vflag.IntVar(&Port, "port", 8000, "The port to bind the web server to.")
 	htp.PreInit()
 
@@ -177,7 +179,7 @@ func WriteHandlebarsFile(r *http.Request, w http.ResponseWriter, path string, co
 
 func StartServer() {
 	htp.RegisterFileSystem(MFS)
-	htp.StartServer(Port)
+	htp.StartServer(Bind, Port)
 }
 
 // FixBareVersion will convert a 'vMASTER' version string to a string

--- a/etc.go
+++ b/etc.go
@@ -53,7 +53,7 @@ func PreInit() {
 	vflag.StringArrayVar(&appFlagTheme, "theme", []string{}, "A CLI way to add config themes.")
 	vflag.StringVar(&ConfigPath, "config", homedirV+"/.config/"+AppID+"/config.json", "")
 	vflag.StringVar(&JWTSecret, "jwt-secret", util.RandomString(64), "Private secret to sign and verify JWT auth tokens with.")
-	vflag.StringVar(&Bind, "bind", "127.0.0.1", "IP to bind")
+	vflag.StringVar(&Bind, "bind", "0.0.0.0", "IP to bind")
 	vflag.IntVar(&Port, "port", 8000, "The port to bind the web server to.")
 	htp.PreInit()
 

--- a/htp/htp.go
+++ b/htp/htp.go
@@ -216,7 +216,7 @@ func Base() string {
 }
 
 // StartServer initializes this server and listens on port
-func StartServer(port int) {
+func StartServer(bind string, port int) {
 	p := strconv.Itoa(port)
 	util.DieOnError(util.Assert(util.IsPortAvailable(port), "Binding to port "+p+" failed."), "It may be taken or you may not have permission to. Aborting!")
 	util.Log("Starting server on port " + p)
@@ -226,7 +226,7 @@ func StartServer(port int) {
 	util.Log("Initialization complete.")
 	srv = &http.Server{
 		Handler: router,
-		Addr:    ":" + p,
+		Addr:    bind + ":" + p,
 	}
 	srv.ListenAndServe()
 }


### PR DESCRIPTION
Adds a IP bind parameter to the `htp` web server, defaults to 0.0.0.0 as to not break any existing setups/configurations.